### PR TITLE
update importable action_item call to have name

### DIFF
--- a/lib/active_admin_importable/dsl.rb
+++ b/lib/active_admin_importable/dsl.rb
@@ -1,7 +1,7 @@
 module ActiveAdminImportable
   module DSL
     def active_admin_importable(&block)
-      action_item :only => :index do
+      action_item :edit, :only => :index do
         link_to "Import #{active_admin_config.resource_name.to_s.pluralize}", :action => 'upload_csv'
       end
 


### PR DESCRIPTION
Fixes deprecation warning for active admin action item
